### PR TITLE
add failing test for pid stability

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -40,9 +40,49 @@ test('run', function (t) {
   }
 })
 
-test('run teardown', function (t) {
+test('rm time', function (t) {
   t.plan(1)
   run('psy rm time', function (err) {
+    t.ifError(err)
+  })
+})
+
+test('long lived process pid is stable', function (t) {
+  run('psy start -n time2'
+    + ' -l ' + path.join(env.PSY_PATH, 'time2.log')
+    + ' -- bash -c "while true; do date; sleep 0.1; done"',
+    ready)
+  function ready (err) {
+    t.ifError(err)
+    getPid(function (err, pidA) {
+      t.ifError(err)
+      t.ok(pidA, 'get first pid')
+      setTimeout(function () {
+        getPid(function (err, pidB) {
+          t.ifError(err)
+          t.ok(pidB, 'get second pid')
+          t.equal(pidA, pidB, 'pids match')
+          t.end()
+        })
+      }, 1000)
+    })
+  }
+
+  function getPid (cb) {
+    run('psy ls', function (err, stdout, stderr) {
+      if (err) return cb(err)
+      var rows = stdout.split('\n').filter(Boolean).map(function (line) {
+        return line.split('  ')
+      })
+      if (!rows.length) return cb(new Error('psy ls returned no results'))
+      cb(null, rows[0][2])
+    })
+  }
+})
+
+test('rm time2', function (t) {
+  t.plan(1)
+  run('psy rm time2', function (err) {
     t.ifError(err)
   })
 })


### PR DESCRIPTION
note: the existing test failed for me too on os x, heres the full test output for me:

```
🐈  npm test

> psy@1.7.0 test /Users/max/src/js/psy
> tape test/*.js

/var/folders/_l/wflb9kxs53xfcflxj6wp5mgr0000gn/T/psy-test-0.10265363124199212
TAP version 13
# run
ok 1 null
ok 2 should be equal
ok 3 should be equal
ok 4 should be equal
ok 5 null
not ok 6 should be equal
  ---
    operator: equal
    expected: 3
    actual:   0
    at: maybeClose (internal/child_process.js:818:16)
  ...

# rm time
ok 7 null
# long lived process pid is stable
ok 8 null
ok 9 null
ok 10 get first pid
not ok 11 Error: psy ls returned no results
  ---
    operator: error
    expected: |-
      undefined
    actual: |-
      [Error: psy ls returned no results]
    at: maybeClose (internal/child_process.js:818:16)
    stack: |-
      Error: psy ls returned no results
          at /Users/max/src/js/psy/test/run.js:77:35
          at ChildProcess.exithandler (child_process.js:194:7)
          at emitTwo (events.js:87:13)
          at ChildProcess.emit (events.js:172:7)
          at maybeClose (internal/child_process.js:818:16)
          at Socket.<anonymous> (internal/child_process.js:319:11)
          at emitOne (events.js:77:13)
          at Socket.emit (events.js:169:7)
          at Pipe._onclose (net.js:469:12)
  ...
not ok 12 get second pid
  ---
    operator: ok
    expected: true
    actual:   undefined
    at: maybeClose (internal/child_process.js:818:16)
  ...
not ok 13 pids match
  ---
    operator: equal
    expected: undefined
    actual:   '29967'
    at: maybeClose (internal/child_process.js:818:16)
  ...
# rm time2
ok 14 null

1..14
# tests 14
# pass  10
# fail  4

```