### PR TITLE
Use new timeago.js library

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -12,7 +12,7 @@ var cmd = argv._[0]
 if (cmd === 'help' || argv.help) return usage(0)
 
 var defined = require('defined')
-var timeago = require('timeago')
+var timeago = require('timeago.js')()
 var table = require('text-table')
 var configDir = require('xdg-basedir').config
 var randomBytes = require('crypto').randomBytes
@@ -114,7 +114,7 @@ function formatList (items) {
   return table(items.map(function (item) {
     return [
       item.id, item.status, item.pid === undefined ? '---' : item.pid,
-      item.started ? timeago(new Date(item.started)) : '---',
+      item.started ? timeago.format(new Date(item.started)) : '---',
       item.command.join(' ')
     ]
   })) + (items.length ? '\n' : '')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sprintf": "^0.1.5",
     "text-table": "^0.2.0",
     "through2": "^0.6.5",
-    "timeago": "^0.2.0",
+    "timeago.js": "^1.0.9",
     "xdg-basedir": "^2.0.0",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
I'm a `pys` user and developer, also the author of [timeago.js](http://timeago.org/). 

This library is `~2KB`, has `no dependencies` and includes several built-in locales. It also updates the timestamp on the page in realtime.
