### PR TITLE
fix(index): default args

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = Psy
 
 function Psy (args) {
   if (!(this instanceof Psy)) return new Psy(args)
+  args = args || {}
   this.opts = defaults(args)
 }
 


### PR DESCRIPTION
Make sure default args exist so `defaults` doesn't crash